### PR TITLE
feat(groups): Add blink.cmp

### DIFF
--- a/lua/dracula/config.lua
+++ b/lua/dracula/config.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-M.version = "2.2.0"
+M.version = "2.3.0"
 
 ---@class DraculaConfig
 ---@field style? DraculaStyle

--- a/lua/dracula/groups/blink.lua
+++ b/lua/dracula/groups/blink.lua
@@ -1,0 +1,29 @@
+local M = {}
+
+M.url = "https://github.com/Saghen/blink.cmp"
+
+---@type DraculaHighlightsFn
+function M.get(c)
+    local ret = {
+        BlinkCmpDoc                 = { fg = c.fg, bg = c.float.bg },
+        BlinkCmpDocBorder           = { fg = c.border, bg = c.float.bg },
+        BlinkCmpGhostText           = { fg = c.inactive },
+        BlinkCmpKindCodeium         = { fg = c.teal, bg = c.none },
+        BlinkCmpKindCopilot         = { fg = c.teal, bg = c.none },
+        BlinkCmpKindDefault         = { fg = c.dark, bg = c.none },
+        BlinkCmpKindSupermaven      = { fg = c.teal, bg = c.none },
+        BlinkCmpKindTabNine         = { fg = c.teal, bg = c.none },
+        BlinkCmpLabel               = { fg = c.fg, bg = c.none },
+        BlinkCmpLabelDeprecated     = { fg = c.gutter.fg, bg = c.none, strikethrough = true },
+        BlinkCmpLabelMatch          = { fg = c.cyan, bg = c.none },
+        BlinkCmpMenu                = { fg = c.fg, bg = c.float.bg },
+        BlinkCmpMenuBorder          = { fg = c.border, bg = c.float.bg },
+        BlinkCmpSignatureHelp       = { fg = c.fg, bg = c.float.bg },
+        BlinkCmpSignatureHelpBorder = { fg = c.border, bg = c.float.bg },
+    }
+
+    require("dracula.groups.kinds").kinds(ret, "BlinkCmpKind%s")
+    return ret
+end
+
+return M

--- a/lua/dracula/groups/blink.lua
+++ b/lua/dracula/groups/blink.lua
@@ -10,7 +10,7 @@ function M.get(c)
         BlinkCmpGhostText           = { fg = c.inactive },
         BlinkCmpKindCodeium         = { fg = c.teal, bg = c.none },
         BlinkCmpKindCopilot         = { fg = c.teal, bg = c.none },
-        BlinkCmpKindDefault         = { fg = c.dark, bg = c.none },
+        BlinkCmpKindDefault         = { fg = c.dark.fg, bg = c.none },
         BlinkCmpKindSupermaven      = { fg = c.teal, bg = c.none },
         BlinkCmpKindTabNine         = { fg = c.teal, bg = c.none },
         BlinkCmpLabel               = { fg = c.fg, bg = c.none },

--- a/lua/dracula/groups/init.lua
+++ b/lua/dracula/groups/init.lua
@@ -9,6 +9,7 @@ M.plugins = {
   ["ale"] = "ale",
   ["alpha-nvim"] = "alpha",
   ["barbar.nvim"] = "barbar",
+  ["blink.cmp"] = "blink",
   ["bufferline.nvim"] = "bufferline",
   ["dashboard-nvim"] = "dashboard",
   ["flash.nvim"] = "flash",


### PR DESCRIPTION
Hi,
I want to add support for [blink.cmp](https://github.com/Saghen/blink.cmp). I followed the config file of `cmp.lua` and the blink config of [tokyonight](https://github.com/folke/tokyonight.nvim/blob/main/lua/tokyonight/groups/blink.lua). But it doesn't work fine. I got the error
```
Failed to run `init` for **dracula.nvim**

vim/_editor.lua:0: /Users/ketch/.config/nvim/init.lua..nvim_exec2() called at /Users/ketch/.config/nvim/init.lua:0../Users/ketch/.local/share/nvim/lazy/dracula.nvim/colors/dracula.lua: Vim(colorscheme):E5113: Error while calling lua chunk: ...local/share/nvim/lazy/dracula.nvim/lua/dracula/theme.lua:19: Invalid 'fg': expected String or Integer
stack traceback:
	[C]: in function 'nvim_set_hl'
	...local/share/nvim/lazy/dracula.nvim/lua/dracula/theme.lua:19: in function 'load'
	...h/.local/share/nvim/lazy/dracula.nvim/colors/dracula.lua:1: in main chunk
	[C]: in function 'nvim_exec2'
	vim/_editor.lua: in function 'cmd'
	/Users/ketch/.config/nvim/lua/plugins/dracula.lua:7: in function 'init'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:115: in function <...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:114>
	[C]: in function 'xpcall'
	.../.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/util.lua:135: in function 'try'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:114: in function 'startup'
	...ketch/.local/share/nvim/lazy/lazy.nvim/lua/lazy/init.lua:112: in function 'setup'
	/Users/ketch/.config/nvim/lua/plugins.lua:14: in main chunk
	[C]: in function 'require'
	/Users/ketch/.config/nvim/init.lua:5: in main chunk

# stacktrace:
  - vim/_editor.lua:0 _in_ **cmd**
  - ~/.config/nvim/lua/plugins/dracula.lua:7 _in_ **init**
  - ~/.config/nvim/lua/plugins.lua:14
  - ~/.config/nvim/init.lua:5
```

I have no idea about how to fix it. Maybe you can kindly take a look or feel free to reject if you don't like. Thanks!